### PR TITLE
Fill the current release notes, GNOME 50.

### DIFF
--- a/.github/fill-release-notes.sh
+++ b/.github/fill-release-notes.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+# Fill the newest <release> stub from the Debian changelog inside the .deb.
+# Usage: .github/fill-release-notes.sh [changelog]
+set -euo pipefail
+cd "$(dirname "$0")/.."
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+
+if [[ ${1-} ]]; then
+    changelog=$1
+else
+    changelog=$tmp/changelog
+    url=$(grep -oE 'https://[^ ]*/surfshark_[0-9][^ ]*_amd64\.deb' com.surfshark.Surfshark.yaml | head -1)
+    echo "Fetching changelog from $url" >&2
+    curl -fsSL "$url" -o "$tmp/surfshark.deb"
+    bsdtar -Oxf "$tmp/surfshark.deb" data.tar.xz |
+        bsdtar -xOf - '*/doc/surfshark/changelog.gz' | gzip -dc >"$changelog"
+fi
+
+ver=$(sed -n '1s/^surfshark (\(.*\)).*/\1/p' "$changelog")
+meta_ver=$(grep -oE '<release version="[^"]+"' com.surfshark.Surfshark.metainfo.xml | head -1)
+meta_ver=${meta_ver#*version=\"}
+meta_ver=${meta_ver%\"}
+[[ $meta_ver == "$ver" ]] || {
+    echo "Newest metainfo is $meta_ver, changelog is $ver" >&2
+    exit 1
+}
+
+{
+    echo '            <description>'
+    echo '                <ul>'
+    while IFS= read -r line; do
+        [[ $line == ' -- '* ]] && break
+        [[ $line =~ ^[[:space:]]+\*[[:space:]]+(.*)$ ]] || continue
+        text=${BASH_REMATCH[1]}
+        text=${text//'&'/'&amp;'}
+        text=${text//'<'/'&lt;'}
+        text=${text//'>'/'&gt;'}
+        echo "                    <li>$text</li>"
+    done <"$changelog"
+    echo '                </ul>'
+    echo '            </description>'
+} >"$tmp/desc"
+grep -q '<li>' "$tmp/desc" || { echo "No changelog bullets for $ver" >&2; exit 1; }
+
+want=0
+filled=0
+while IFS= read -r line; do
+    if (( want )); then
+        want=0
+        if [[ $line == *'<description></description>'* || $line == *'<description/>'* ]]; then
+            cat "$tmp/desc"
+            filled=1
+            continue
+        fi
+    fi
+    [[ $line == *"<release version=\"$ver\""* ]] && want=1
+    printf '%s\n' "$line"
+done <com.surfshark.Surfshark.metainfo.xml >"$tmp/out"
+
+if (( filled )); then
+    mv "$tmp/out" com.surfshark.Surfshark.metainfo.xml
+    echo "Filled release $ver" >&2
+else
+    echo "Release $ver already has notes" >&2
+fi

--- a/.github/fill-release-notes.sh
+++ b/.github/fill-release-notes.sh
@@ -10,7 +10,8 @@ if [[ ${1-} ]]; then
     changelog=$1
 else
     changelog=$tmp/changelog
-    url=$(grep -oE 'https://[^ ]*/surfshark_[0-9][^ ]*_amd64\.deb' com.surfshark.Surfshark.yaml | head -1)
+    url=$(grep -oE 'https://ocean\.surfshark\.com/[^ ]*/surfshark_[0-9][^ ]*_amd64\.deb' com.surfshark.Surfshark.yaml | head -1)
+    [[ $url ]] || { echo "No ocean.surfshark.com .deb URL found in com.surfshark.Surfshark.yaml" >&2; exit 1; }
     echo "Fetching changelog from $url" >&2
     curl -fsSL "$url" -o "$tmp/surfshark.deb"
     bsdtar -Oxf "$tmp/surfshark.deb" data.tar.xz |
@@ -42,6 +43,17 @@ meta_ver=${meta_ver%\"}
     echo '            </description>'
 } >"$tmp/desc"
 grep -q '<li>' "$tmp/desc" || { echo "No changelog bullets for $ver" >&2; exit 1; }
+
+# Contract: the release to fill must be written as an open tag whose *next*
+# line is an empty description placeholder, e.g.
+#     <release version="X" date="Y">
+#         <description></description>
+#     </release>
+# A self-closing stub (<release version="X" ... />) has no slot to fill.
+if grep -qE "<release version=\"$ver\"[^>]*/>" com.surfshark.Surfshark.metainfo.xml; then
+    echo "Release $ver is a self-closing stub; rewrite it with an empty <description></description> line to fill" >&2
+    exit 1
+fi
 
 want=0
 filled=0

--- a/.github/workflows/fill-release-notes.yaml
+++ b/.github/workflows/fill-release-notes.yaml
@@ -7,14 +7,18 @@ on:
       - com.surfshark.Surfshark.metainfo.xml
   workflow_dispatch: {}
 
-permissions:
-  contents: write
+# Serialize per branch so overlapping synchronize events cannot race on push.
+concurrency:
+  group: fill-release-notes-${{ github.event.pull_request.head.ref || github.ref_name }}
+  cancel-in-progress: true
 
 jobs:
   fill-release-notes:
     runs-on: ubuntu-latest
-    # Same-repo branches only (flathubbot and maintainers); fork PRs get a
-    # read-only token and could not push anyway.
+    permissions:
+      contents: write
+    # Same-repo branches only (flathubbot and maintainers). Fork PRs match
+    # neither branch of this condition, so the job is skipped entirely.
     if: github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
@@ -27,12 +31,21 @@ jobs:
           bash .github/fill-release-notes.sh
 
       - name: Push filled notes
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
         run: |
           if git diff --quiet; then
             echo "Release notes already filled"
             exit 0
           fi
+          # Never commit straight to the default branch on manual dispatch;
+          # release notes must land through a reviewed PR.
+          if [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" \
+                && "$GITHUB_REF_NAME" == "$DEFAULT_BRANCH" ]]; then
+            echo "Refusing to push filled notes directly to the default branch" >&2
+            exit 1
+          fi
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git commit -am "Fill release notes from the Debian changelog"
+          git commit -m "Fill release notes from the Debian changelog" com.surfshark.Surfshark.metainfo.xml
           git push

--- a/.github/workflows/fill-release-notes.yaml
+++ b/.github/workflows/fill-release-notes.yaml
@@ -1,0 +1,38 @@
+name: Fill release notes
+on:
+  pull_request:
+    types: [opened, synchronize]
+    paths:
+      - com.surfshark.Surfshark.yaml
+      - com.surfshark.Surfshark.metainfo.xml
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+
+jobs:
+  fill-release-notes:
+    runs-on: ubuntu-latest
+    # Same-repo branches only (flathubbot and maintainers); fork PRs get a
+    # read-only token and could not push anyway.
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
+        with:
+          ref: ${{ github.event.pull_request.head.ref || github.ref_name }}
+
+      - name: Fill release notes from the .deb changelog
+        run: |
+          command -v bsdtar >/dev/null || sudo apt-get install -y -qq libarchive-tools
+          bash .github/fill-release-notes.sh
+
+      - name: Push filled notes
+        run: |
+          if git diff --quiet; then
+            echo "Release notes already filled"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git commit -am "Fill release notes from the Debian changelog"
+          git push

--- a/com.surfshark.Surfshark.metainfo.xml
+++ b/com.surfshark.Surfshark.metainfo.xml
@@ -67,7 +67,13 @@
     </branding>
     <releases>
         <release version="3.12.0" date="2026-08-03">
-            <description></description>
+            <description>
+                <ul>
+                    <li>Always show autoconnection widget.</li>
+                    <li>Pass theme to web.</li>
+                    <li>Other minor updates.</li>
+                </ul>
+            </description>
         </release>
         <release version="3.11.0" date="2026-07-09">
             <description/>

--- a/com.surfshark.Surfshark.yaml
+++ b/com.surfshark.Surfshark.yaml
@@ -2,7 +2,7 @@
 
 app-id: com.surfshark.Surfshark
 runtime: org.gnome.Platform
-runtime-version: '49'
+runtime-version: '50'
 base: org.electronjs.Electron2.BaseApp
 base-version: '25.08'
 sdk: org.gnome.Sdk
@@ -21,6 +21,8 @@ finish-args:
   - --share=ipc
   - --share=network
   - --system-talk-name=org.freedesktop.NetworkManager
+  # logind Inhibit + PrepareForShutdown so the daemon can tear down the VPN on OS shutdown
+  - --system-talk-name=org.freedesktop.login1
   - --talk-name=org.freedesktop.secrets
   - --talk-name=org.kde.StatusNotifierWatcher
   - --env=XCURSOR_PATH=/run/host/user-share/icons:/run/host/share/icons

--- a/com.surfshark.Surfshark.yaml
+++ b/com.surfshark.Surfshark.yaml
@@ -21,8 +21,6 @@ finish-args:
   - --share=ipc
   - --share=network
   - --system-talk-name=org.freedesktop.NetworkManager
-  # logind Inhibit + PrepareForShutdown so the daemon can tear down the VPN on OS shutdown
-  - --system-talk-name=org.freedesktop.login1
   - --talk-name=org.freedesktop.secrets
   - --talk-name=org.kde.StatusNotifierWatcher
   - --env=XCURSOR_PATH=/run/host/user-share/icons:/run/host/share/icons


### PR DESCRIPTION
## Summary
- Fill the newest `<release>` description from the Debian changelog inside the `.deb`, and add a workflow that does this on flathubbot PRs.
- Update the GNOME runtime to 50.

## Test plan
- [ ] Confirm 3.12.0 metainfo notes match the Debian changelog
- [ ] Confirm the fill-release-notes workflow only runs on same-repo PRs
- [ ] Confirm the app still builds against GNOME 50